### PR TITLE
feat(github): change border of inprogress for lots of items

### DIFF
--- a/js/check-in-progress.js
+++ b/js/check-in-progress.js
@@ -1,0 +1,22 @@
+const check_in_progress = () => {
+  var xpath = "//span[text()='In Progress']";
+  var matchingElement = document.evaluate(
+    xpath,
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null
+  ).singleNodeValue;
+  var parentOfSpan = matchingElement.parentNode;
+  var currentInProgress = parentOfSpan.nextSibling.textContent;
+  if (currentInProgress < 3) return;
+
+  var area = parentOfSpan.parentNode.parentNode.parentNode.parentNode;
+  var colour = currentInProgress > 4 ? "red" : "orange";
+  area.style.border = `${colour} 3px solid`;
+};
+
+window.addEventListener("load", function () {
+  // even with the load we have to make sure everything is loaded...Ugh!
+  this.setTimeout(check_in_progress, 1000);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,12 @@
   ],
   "content_scripts": [{
     "matches": ["https://github.com/PlayerData/**/pull/*"],
-    "js": ["js/check-smoke-tests.js"],    "run_at": "document_end"
+    "js": ["js/check-smoke-tests.js"],
+    "run_at": "document_end"
+  }, {
+    "matches": ["https://github.com/orgs/PlayerData/projects/**"],
+    "js": ["js/check-in-progress.js"],
+    "run_at": "document_end"
   }],
   "chrome_url_overrides": {
     "newtab": "shownewtab.html"


### PR DESCRIPTION
<img width="739" alt="Screenshot 2022-08-12 at 13 33 09" src="https://user-images.githubusercontent.com/337812/184354844-481678e2-4738-4f99-a877-d175f7a86130.png">
<img width="724" alt="Screenshot 2022-08-12 at 13 32 51" src="https://user-images.githubusercontent.com/337812/184354853-17ae0350-4a07-4969-9922-b9889c9490d0.png">
<img width="721" alt="Screenshot 2022-08-12 at 13 32 39" src="https://user-images.githubusercontent.com/337812/184354858-15516459-57a5-4265-b41f-0ce9f77d95e5.png">
